### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,7 @@
 {
-	"packages/client": "6.0.2",
-	"packages/server": "5.1.5",
-	"packages/common": "4.1.5",
-	"packages/types": "1.3.5",
-	"packages/eslint": "1.0.2"
+	"packages/client": "6.0.3",
+	"packages/server": "5.1.6",
+	"packages/common": "4.1.6",
+	"packages/types": "1.3.6",
+	"packages/eslint": "1.0.3"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [6.0.3](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v6.0.2...dev-dependencies-client-v6.0.3) (2024-09-15)
+
+
+### Bug Fixes
+
+* bump dependencies to latest ([#410](https://github.com/versini-org/dev-dependencies/issues/410)) ([a59a271](https://github.com/versini-org/dev-dependencies/commit/a59a27111fa9defab07fbde685da846bc33a14f0))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/dev-dependencies-common bumped to 4.1.6
+
 ## [6.0.2](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v6.0.1...dev-dependencies-client-v6.0.2) (2024-09-05)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-client",
-	"version": "6.0.2",
+	"version": "6.0.3",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.1.6](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v4.1.5...dev-dependencies-common-v4.1.6) (2024-09-15)
+
+
+### Bug Fixes
+
+* bump dependencies to latest ([#410](https://github.com/versini-org/dev-dependencies/issues/410)) ([a59a271](https://github.com/versini-org/dev-dependencies/commit/a59a27111fa9defab07fbde685da846bc33a14f0))
+
 ## [4.1.5](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v4.1.4...dev-dependencies-common-v4.1.5) (2024-09-05)
 
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-common",
-	"version": "4.1.5",
+	"version": "4.1.6",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -12,7 +12,9 @@
 		"url": "git@github.com:aversini/dev-dependencies.git"
 	},
 	"type": "module",
-	"files": ["biome.json"],
+	"files": [
+		"biome.json"
+	],
 	"exports": {
 		"./biome": "./biome.json"
 	},

--- a/packages/eslint/CHANGELOG.md
+++ b/packages/eslint/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.3](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-eslint-v1.0.2...dev-dependencies-eslint-v1.0.3) (2024-09-15)
+
+
+### Bug Fixes
+
+* bump dependencies to latest ([#410](https://github.com/versini-org/dev-dependencies/issues/410)) ([a59a271](https://github.com/versini-org/dev-dependencies/commit/a59a27111fa9defab07fbde685da846bc33a14f0))
+
 ## [1.0.2](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-eslint-v1.0.1...dev-dependencies-eslint-v1.0.2) (2024-09-05)
 
 

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-eslint",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [5.1.6](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-server-v5.1.5...dev-dependencies-server-v5.1.6) (2024-09-15)
+
+
+### Bug Fixes
+
+* bump dependencies to latest ([#410](https://github.com/versini-org/dev-dependencies/issues/410)) ([a59a271](https://github.com/versini-org/dev-dependencies/commit/a59a27111fa9defab07fbde685da846bc33a14f0))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/dev-dependencies-common bumped to 4.1.6
+
 ## [5.1.5](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-server-v5.1.4...dev-dependencies-server-v5.1.5) (2024-09-05)
 
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-server",
-	"version": "5.1.5",
+	"version": "5.1.6",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.3.6](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v1.3.5...dev-dependencies-types-v1.3.6) (2024-09-15)
+
+
+### Bug Fixes
+
+* bump dependencies to latest ([#410](https://github.com/versini-org/dev-dependencies/issues/410)) ([a59a271](https://github.com/versini-org/dev-dependencies/commit/a59a27111fa9defab07fbde685da846bc33a14f0))
+
 ## [1.3.5](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v1.3.4...dev-dependencies-types-v1.3.5) (2024-09-05)
 
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-types",
-	"version": "1.3.5",
+	"version": "1.3.6",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>dev-dependencies-client: 6.0.3</summary>

## [6.0.3](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v6.0.2...dev-dependencies-client-v6.0.3) (2024-09-15)


### Bug Fixes

* bump dependencies to latest ([#410](https://github.com/versini-org/dev-dependencies/issues/410)) ([a59a271](https://github.com/versini-org/dev-dependencies/commit/a59a27111fa9defab07fbde685da846bc33a14f0))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/dev-dependencies-common bumped to 4.1.6
</details>

<details><summary>dev-dependencies-common: 4.1.6</summary>

## [4.1.6](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v4.1.5...dev-dependencies-common-v4.1.6) (2024-09-15)


### Bug Fixes

* bump dependencies to latest ([#410](https://github.com/versini-org/dev-dependencies/issues/410)) ([a59a271](https://github.com/versini-org/dev-dependencies/commit/a59a27111fa9defab07fbde685da846bc33a14f0))
</details>

<details><summary>dev-dependencies-eslint: 1.0.3</summary>

## [1.0.3](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-eslint-v1.0.2...dev-dependencies-eslint-v1.0.3) (2024-09-15)


### Bug Fixes

* bump dependencies to latest ([#410](https://github.com/versini-org/dev-dependencies/issues/410)) ([a59a271](https://github.com/versini-org/dev-dependencies/commit/a59a27111fa9defab07fbde685da846bc33a14f0))
</details>

<details><summary>dev-dependencies-server: 5.1.6</summary>

## [5.1.6](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-server-v5.1.5...dev-dependencies-server-v5.1.6) (2024-09-15)


### Bug Fixes

* bump dependencies to latest ([#410](https://github.com/versini-org/dev-dependencies/issues/410)) ([a59a271](https://github.com/versini-org/dev-dependencies/commit/a59a27111fa9defab07fbde685da846bc33a14f0))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/dev-dependencies-common bumped to 4.1.6
</details>

<details><summary>dev-dependencies-types: 1.3.6</summary>

## [1.3.6](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v1.3.5...dev-dependencies-types-v1.3.6) (2024-09-15)


### Bug Fixes

* bump dependencies to latest ([#410](https://github.com/versini-org/dev-dependencies/issues/410)) ([a59a271](https://github.com/versini-org/dev-dependencies/commit/a59a27111fa9defab07fbde685da846bc33a14f0))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).