### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-	"packages/client": "6.0.4",
+	"packages/client": "6.0.5",
 	"packages/server": "5.1.7",
 	"packages/common": "4.1.7",
 	"packages/types": "1.3.7",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.0.5](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v6.0.4...dev-dependencies-client-v6.0.5) (2024-09-19)
+
+
+### Bug Fixes
+
+* bump vitest from 1.x to 2.x ([#419](https://github.com/versini-org/dev-dependencies/issues/419)) ([2f9f1cb](https://github.com/versini-org/dev-dependencies/commit/2f9f1cb4581a1dc618ec5cf4cde82464d43a563e))
+
 ## [6.0.4](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v6.0.3...dev-dependencies-client-v6.0.4) (2024-09-19)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-client",
-	"version": "6.0.4",
+	"version": "6.0.5",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>dev-dependencies-client: 6.0.5</summary>

## [6.0.5](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v6.0.4...dev-dependencies-client-v6.0.5) (2024-09-19)


### Bug Fixes

* bump vitest from 1.x to 2.x ([#419](https://github.com/versini-org/dev-dependencies/issues/419)) ([2f9f1cb](https://github.com/versini-org/dev-dependencies/commit/2f9f1cb4581a1dc618ec5cf4cde82464d43a563e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).