### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,7 @@
 {
-	"packages/client": "6.0.5",
-	"packages/server": "5.1.7",
-	"packages/common": "4.1.7",
-	"packages/types": "1.3.7",
-	"packages/eslint": "1.0.3"
+	"packages/client": "6.0.6",
+	"packages/server": "5.1.8",
+	"packages/common": "4.1.8",
+	"packages/types": "1.3.8",
+	"packages/eslint": "1.0.4"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [6.0.6](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v6.0.5...dev-dependencies-client-v6.0.6) (2024-09-29)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([#427](https://github.com/versini-org/dev-dependencies/issues/427)) ([4d69169](https://github.com/versini-org/dev-dependencies/commit/4d69169b4e289e89265ab383438117a30cf5442c))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/dev-dependencies-common bumped to 4.1.8
+
 ## [6.0.5](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v6.0.4...dev-dependencies-client-v6.0.5) (2024-09-19)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-client",
-	"version": "6.0.5",
+	"version": "6.0.6",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.1.8](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v4.1.7...dev-dependencies-common-v4.1.8) (2024-09-29)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([#427](https://github.com/versini-org/dev-dependencies/issues/427)) ([4d69169](https://github.com/versini-org/dev-dependencies/commit/4d69169b4e289e89265ab383438117a30cf5442c))
+
 ## [4.1.7](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v4.1.6...dev-dependencies-common-v4.1.7) (2024-09-19)
 
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-common",
-	"version": "4.1.7",
+	"version": "4.1.8",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/eslint/CHANGELOG.md
+++ b/packages/eslint/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.4](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-eslint-v1.0.3...dev-dependencies-eslint-v1.0.4) (2024-09-29)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([#427](https://github.com/versini-org/dev-dependencies/issues/427)) ([4d69169](https://github.com/versini-org/dev-dependencies/commit/4d69169b4e289e89265ab383438117a30cf5442c))
+
 ## [1.0.3](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-eslint-v1.0.2...dev-dependencies-eslint-v1.0.3) (2024-09-15)
 
 

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-eslint",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [5.1.8](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-server-v5.1.7...dev-dependencies-server-v5.1.8) (2024-09-29)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([#427](https://github.com/versini-org/dev-dependencies/issues/427)) ([4d69169](https://github.com/versini-org/dev-dependencies/commit/4d69169b4e289e89265ab383438117a30cf5442c))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/dev-dependencies-common bumped to 4.1.8
+
 ## [5.1.7](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-server-v5.1.6...dev-dependencies-server-v5.1.7) (2024-09-19)
 
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-server",
-	"version": "5.1.7",
+	"version": "5.1.8",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.3.8](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v1.3.7...dev-dependencies-types-v1.3.8) (2024-09-29)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([#427](https://github.com/versini-org/dev-dependencies/issues/427)) ([4d69169](https://github.com/versini-org/dev-dependencies/commit/4d69169b4e289e89265ab383438117a30cf5442c))
+
 ## [1.3.7](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v1.3.6...dev-dependencies-types-v1.3.7) (2024-09-19)
 
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-types",
-	"version": "1.3.7",
+	"version": "1.3.8",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>dev-dependencies-client: 6.0.6</summary>

## [6.0.6](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v6.0.5...dev-dependencies-client-v6.0.6) (2024-09-29)


### Bug Fixes

* bump non-breaking dependencies to latest ([#427](https://github.com/versini-org/dev-dependencies/issues/427)) ([4d69169](https://github.com/versini-org/dev-dependencies/commit/4d69169b4e289e89265ab383438117a30cf5442c))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/dev-dependencies-common bumped to 4.1.8
</details>

<details><summary>dev-dependencies-common: 4.1.8</summary>

## [4.1.8](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v4.1.7...dev-dependencies-common-v4.1.8) (2024-09-29)


### Bug Fixes

* bump non-breaking dependencies to latest ([#427](https://github.com/versini-org/dev-dependencies/issues/427)) ([4d69169](https://github.com/versini-org/dev-dependencies/commit/4d69169b4e289e89265ab383438117a30cf5442c))
</details>

<details><summary>dev-dependencies-eslint: 1.0.4</summary>

## [1.0.4](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-eslint-v1.0.3...dev-dependencies-eslint-v1.0.4) (2024-09-29)


### Bug Fixes

* bump non-breaking dependencies to latest ([#427](https://github.com/versini-org/dev-dependencies/issues/427)) ([4d69169](https://github.com/versini-org/dev-dependencies/commit/4d69169b4e289e89265ab383438117a30cf5442c))
</details>

<details><summary>dev-dependencies-server: 5.1.8</summary>

## [5.1.8](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-server-v5.1.7...dev-dependencies-server-v5.1.8) (2024-09-29)


### Bug Fixes

* bump non-breaking dependencies to latest ([#427](https://github.com/versini-org/dev-dependencies/issues/427)) ([4d69169](https://github.com/versini-org/dev-dependencies/commit/4d69169b4e289e89265ab383438117a30cf5442c))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/dev-dependencies-common bumped to 4.1.8
</details>

<details><summary>dev-dependencies-types: 1.3.8</summary>

## [1.3.8](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v1.3.7...dev-dependencies-types-v1.3.8) (2024-09-29)


### Bug Fixes

* bump non-breaking dependencies to latest ([#427](https://github.com/versini-org/dev-dependencies/issues/427)) ([4d69169](https://github.com/versini-org/dev-dependencies/commit/4d69169b4e289e89265ab383438117a30cf5442c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).