### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,7 @@
 {
-	"packages/client": "6.0.6",
-	"packages/server": "5.1.8",
-	"packages/common": "4.1.8",
-	"packages/types": "1.3.8",
-	"packages/eslint": "1.0.4"
+	"packages/client": "6.0.7",
+	"packages/server": "5.1.9",
+	"packages/common": "4.1.9",
+	"packages/types": "1.3.9",
+	"packages/eslint": "1.0.5"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [6.0.7](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v6.0.6...dev-dependencies-client-v6.0.7) (2024-10-07)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([#434](https://github.com/versini-org/dev-dependencies/issues/434)) ([39d5fe5](https://github.com/versini-org/dev-dependencies/commit/39d5fe511c5031b763905a7490ef901afa191fd6))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/dev-dependencies-common bumped to 4.1.9
+
 ## [6.0.6](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v6.0.5...dev-dependencies-client-v6.0.6) (2024-09-29)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-client",
-	"version": "6.0.6",
+	"version": "6.0.7",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.1.9](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v4.1.8...dev-dependencies-common-v4.1.9) (2024-10-07)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([#434](https://github.com/versini-org/dev-dependencies/issues/434)) ([39d5fe5](https://github.com/versini-org/dev-dependencies/commit/39d5fe511c5031b763905a7490ef901afa191fd6))
+
 ## [4.1.8](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v4.1.7...dev-dependencies-common-v4.1.8) (2024-09-29)
 
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-common",
-	"version": "4.1.8",
+	"version": "4.1.9",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/eslint/CHANGELOG.md
+++ b/packages/eslint/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.5](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-eslint-v1.0.4...dev-dependencies-eslint-v1.0.5) (2024-10-07)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([#434](https://github.com/versini-org/dev-dependencies/issues/434)) ([39d5fe5](https://github.com/versini-org/dev-dependencies/commit/39d5fe511c5031b763905a7490ef901afa191fd6))
+
 ## [1.0.4](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-eslint-v1.0.3...dev-dependencies-eslint-v1.0.4) (2024-09-29)
 
 

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-eslint",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.1.9](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-server-v5.1.8...dev-dependencies-server-v5.1.9) (2024-10-07)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/dev-dependencies-common bumped to 4.1.9
+
 ## [5.1.8](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-server-v5.1.7...dev-dependencies-server-v5.1.8) (2024-09-29)
 
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-server",
-	"version": "5.1.8",
+	"version": "5.1.9",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.3.9](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v1.3.8...dev-dependencies-types-v1.3.9) (2024-10-07)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([#434](https://github.com/versini-org/dev-dependencies/issues/434)) ([39d5fe5](https://github.com/versini-org/dev-dependencies/commit/39d5fe511c5031b763905a7490ef901afa191fd6))
+
 ## [1.3.8](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v1.3.7...dev-dependencies-types-v1.3.8) (2024-09-29)
 
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-types",
-	"version": "1.3.8",
+	"version": "1.3.9",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>dev-dependencies-client: 6.0.7</summary>

## [6.0.7](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v6.0.6...dev-dependencies-client-v6.0.7) (2024-10-07)


### Bug Fixes

* bump non-breaking dependencies to latest ([#434](https://github.com/versini-org/dev-dependencies/issues/434)) ([39d5fe5](https://github.com/versini-org/dev-dependencies/commit/39d5fe511c5031b763905a7490ef901afa191fd6))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/dev-dependencies-common bumped to 4.1.9
</details>

<details><summary>dev-dependencies-common: 4.1.9</summary>

## [4.1.9](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v4.1.8...dev-dependencies-common-v4.1.9) (2024-10-07)


### Bug Fixes

* bump non-breaking dependencies to latest ([#434](https://github.com/versini-org/dev-dependencies/issues/434)) ([39d5fe5](https://github.com/versini-org/dev-dependencies/commit/39d5fe511c5031b763905a7490ef901afa191fd6))
</details>

<details><summary>dev-dependencies-eslint: 1.0.5</summary>

## [1.0.5](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-eslint-v1.0.4...dev-dependencies-eslint-v1.0.5) (2024-10-07)


### Bug Fixes

* bump non-breaking dependencies to latest ([#434](https://github.com/versini-org/dev-dependencies/issues/434)) ([39d5fe5](https://github.com/versini-org/dev-dependencies/commit/39d5fe511c5031b763905a7490ef901afa191fd6))
</details>

<details><summary>dev-dependencies-server: 5.1.9</summary>

## [5.1.9](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-server-v5.1.8...dev-dependencies-server-v5.1.9) (2024-10-07)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/dev-dependencies-common bumped to 4.1.9
</details>

<details><summary>dev-dependencies-types: 1.3.9</summary>

## [1.3.9](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v1.3.8...dev-dependencies-types-v1.3.9) (2024-10-07)


### Bug Fixes

* bump non-breaking dependencies to latest ([#434](https://github.com/versini-org/dev-dependencies/issues/434)) ([39d5fe5](https://github.com/versini-org/dev-dependencies/commit/39d5fe511c5031b763905a7490ef901afa191fd6))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).