### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,7 @@
 {
-	"packages/client": "6.0.8",
-	"packages/server": "5.1.10",
-	"packages/common": "4.1.10",
-	"packages/types": "1.3.10",
-	"packages/eslint": "1.0.5"
+	"packages/client": "7.0.0",
+	"packages/server": "6.0.0",
+	"packages/common": "5.0.0",
+	"packages/types": "2.0.0",
+	"packages/eslint": "2.0.0"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [7.0.0](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v6.0.8...dev-dependencies-client-v7.0.0) (2024-12-03)
+
+
+### ⚠ BREAKING CHANGES
+
+* Vite was bumped from 5.x to 6.x
+
+### Bug Fixes
+
+* bump some breaking dependencies to latest ([#473](https://github.com/versini-org/dev-dependencies/issues/473)) ([fe35c5d](https://github.com/versini-org/dev-dependencies/commit/fe35c5d8ac376dda9c321bc77f2f266c504f367d))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/dev-dependencies-common bumped to 5.0.0
+
 ## [6.0.8](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v6.0.7...dev-dependencies-client-v6.0.8) (2024-10-09)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-client",
-	"version": "6.0.8",
+	"version": "7.0.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [5.0.0](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v4.1.10...dev-dependencies-common-v5.0.0) (2024-12-03)
+
+
+### ⚠ BREAKING CHANGES
+
+* Vite was bumped from 5.x to 6.x
+
+### Bug Fixes
+
+* bump some breaking dependencies to latest ([#473](https://github.com/versini-org/dev-dependencies/issues/473)) ([fe35c5d](https://github.com/versini-org/dev-dependencies/commit/fe35c5d8ac376dda9c321bc77f2f266c504f367d))
+
 ## [4.1.10](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v4.1.9...dev-dependencies-common-v4.1.10) (2024-10-09)
 
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-common",
-	"version": "4.1.10",
+	"version": "5.0.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/eslint/CHANGELOG.md
+++ b/packages/eslint/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.0.0](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-eslint-v1.0.5...dev-dependencies-eslint-v2.0.0) (2024-12-03)
+
+
+### ⚠ BREAKING CHANGES
+
+* Vite was bumped from 5.x to 6.x
+
+### Bug Fixes
+
+* bump some breaking dependencies to latest ([#473](https://github.com/versini-org/dev-dependencies/issues/473)) ([fe35c5d](https://github.com/versini-org/dev-dependencies/commit/fe35c5d8ac376dda9c321bc77f2f266c504f367d))
+
 ## [1.0.5](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-eslint-v1.0.4...dev-dependencies-eslint-v1.0.5) (2024-10-07)
 
 

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-eslint",
-	"version": "1.0.5",
+	"version": "2.0.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [6.0.0](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-server-v5.1.10...dev-dependencies-server-v6.0.0) (2024-12-03)
+
+
+### ⚠ BREAKING CHANGES
+
+* Vite was bumped from 5.x to 6.x
+
+### Bug Fixes
+
+* bump some breaking dependencies to latest ([#473](https://github.com/versini-org/dev-dependencies/issues/473)) ([fe35c5d](https://github.com/versini-org/dev-dependencies/commit/fe35c5d8ac376dda9c321bc77f2f266c504f367d))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/dev-dependencies-common bumped to 5.0.0
+
 ## [5.1.10](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-server-v5.1.9...dev-dependencies-server-v5.1.10) (2024-10-09)
 
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-server",
-	"version": "5.1.10",
+	"version": "6.0.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.0.0](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v1.3.10...dev-dependencies-types-v2.0.0) (2024-12-03)
+
+
+### ⚠ BREAKING CHANGES
+
+* Vite was bumped from 5.x to 6.x
+
+### Bug Fixes
+
+* bump some breaking dependencies to latest ([#473](https://github.com/versini-org/dev-dependencies/issues/473)) ([fe35c5d](https://github.com/versini-org/dev-dependencies/commit/fe35c5d8ac376dda9c321bc77f2f266c504f367d))
+
 ## [1.3.10](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v1.3.9...dev-dependencies-types-v1.3.10) (2024-10-09)
 
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-types",
-	"version": "1.3.10",
+	"version": "2.0.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>dev-dependencies-client: 7.0.0</summary>

## [7.0.0](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v6.0.8...dev-dependencies-client-v7.0.0) (2024-12-03)


### ⚠ BREAKING CHANGES

* Vite was bumped from 5.x to 6.x

### Bug Fixes

* bump some breaking dependencies to latest ([#473](https://github.com/versini-org/dev-dependencies/issues/473)) ([fe35c5d](https://github.com/versini-org/dev-dependencies/commit/fe35c5d8ac376dda9c321bc77f2f266c504f367d))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/dev-dependencies-common bumped to 5.0.0
</details>

<details><summary>dev-dependencies-common: 5.0.0</summary>

## [5.0.0](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v4.1.10...dev-dependencies-common-v5.0.0) (2024-12-03)


### ⚠ BREAKING CHANGES

* Vite was bumped from 5.x to 6.x

### Bug Fixes

* bump some breaking dependencies to latest ([#473](https://github.com/versini-org/dev-dependencies/issues/473)) ([fe35c5d](https://github.com/versini-org/dev-dependencies/commit/fe35c5d8ac376dda9c321bc77f2f266c504f367d))
</details>

<details><summary>dev-dependencies-eslint: 2.0.0</summary>

## [2.0.0](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-eslint-v1.0.5...dev-dependencies-eslint-v2.0.0) (2024-12-03)


### ⚠ BREAKING CHANGES

* Vite was bumped from 5.x to 6.x

### Bug Fixes

* bump some breaking dependencies to latest ([#473](https://github.com/versini-org/dev-dependencies/issues/473)) ([fe35c5d](https://github.com/versini-org/dev-dependencies/commit/fe35c5d8ac376dda9c321bc77f2f266c504f367d))
</details>

<details><summary>dev-dependencies-server: 6.0.0</summary>

## [6.0.0](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-server-v5.1.10...dev-dependencies-server-v6.0.0) (2024-12-03)


### ⚠ BREAKING CHANGES

* Vite was bumped from 5.x to 6.x

### Bug Fixes

* bump some breaking dependencies to latest ([#473](https://github.com/versini-org/dev-dependencies/issues/473)) ([fe35c5d](https://github.com/versini-org/dev-dependencies/commit/fe35c5d8ac376dda9c321bc77f2f266c504f367d))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/dev-dependencies-common bumped to 5.0.0
</details>

<details><summary>dev-dependencies-types: 2.0.0</summary>

## [2.0.0](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v1.3.10...dev-dependencies-types-v2.0.0) (2024-12-03)


### ⚠ BREAKING CHANGES

* Vite was bumped from 5.x to 6.x

### Bug Fixes

* bump some breaking dependencies to latest ([#473](https://github.com/versini-org/dev-dependencies/issues/473)) ([fe35c5d](https://github.com/versini-org/dev-dependencies/commit/fe35c5d8ac376dda9c321bc77f2f266c504f367d))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).