### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,6 +2,6 @@
 	"packages/client": "7.0.0",
 	"packages/server": "6.0.0",
 	"packages/common": "5.0.0",
-	"packages/types": "2.0.0",
+	"packages/types": "2.0.1",
 	"packages/eslint": "2.0.0"
 }

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.0.1](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v2.0.0...dev-dependencies-types-v2.0.1) (2024-12-03)
+
+
+### Bug Fixes
+
+* bump types dependencies to latest ([#475](https://github.com/versini-org/dev-dependencies/issues/475)) ([6abc0f9](https://github.com/versini-org/dev-dependencies/commit/6abc0f9580e5460def0a05c164e603b1f3af0879))
+
 ## [2.0.0](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v1.3.10...dev-dependencies-types-v2.0.0) (2024-12-03)
 
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-types",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>dev-dependencies-types: 2.0.1</summary>

## [2.0.1](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v2.0.0...dev-dependencies-types-v2.0.1) (2024-12-03)


### Bug Fixes

* bump types dependencies to latest ([#475](https://github.com/versini-org/dev-dependencies/issues/475)) ([6abc0f9](https://github.com/versini-org/dev-dependencies/commit/6abc0f9580e5460def0a05c164e603b1f3af0879))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).