### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,7 @@
 {
-	"packages/client": "7.0.0",
-	"packages/server": "6.0.0",
-	"packages/common": "5.0.0",
-	"packages/types": "2.0.1",
+	"packages/client": "7.0.1",
+	"packages/server": "6.0.1",
+	"packages/common": "5.0.1",
+	"packages/types": "2.0.2",
 	"packages/eslint": "2.0.0"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [7.0.1](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v7.0.0...dev-dependencies-client-v7.0.1) (2024-12-11)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([#477](https://github.com/versini-org/dev-dependencies/issues/477)) ([ffd14e9](https://github.com/versini-org/dev-dependencies/commit/ffd14e920bc057e7e2351bac4adc98061d7f6551))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/dev-dependencies-common bumped to 5.0.1
+
 ## [7.0.0](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v6.0.8...dev-dependencies-client-v7.0.0) (2024-12-03)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-client",
-	"version": "7.0.0",
+	"version": "7.0.1",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [5.0.1](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v5.0.0...dev-dependencies-common-v5.0.1) (2024-12-11)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([#477](https://github.com/versini-org/dev-dependencies/issues/477)) ([ffd14e9](https://github.com/versini-org/dev-dependencies/commit/ffd14e920bc057e7e2351bac4adc98061d7f6551))
+* bump non-breaking dependencies to latest ([#479](https://github.com/versini-org/dev-dependencies/issues/479)) ([0f8723c](https://github.com/versini-org/dev-dependencies/commit/0f8723ca6665e8d4b110561f58d56d0bf5691664))
+
 ## [5.0.0](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v4.1.10...dev-dependencies-common-v5.0.0) (2024-12-03)
 
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-common",
-	"version": "5.0.0",
+	"version": "5.0.1",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [6.0.1](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-server-v6.0.0...dev-dependencies-server-v6.0.1) (2024-12-11)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([#477](https://github.com/versini-org/dev-dependencies/issues/477)) ([ffd14e9](https://github.com/versini-org/dev-dependencies/commit/ffd14e920bc057e7e2351bac4adc98061d7f6551))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/dev-dependencies-common bumped to 5.0.1
+
 ## [6.0.0](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-server-v5.1.10...dev-dependencies-server-v6.0.0) (2024-12-03)
 
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-server",
-	"version": "6.0.0",
+	"version": "6.0.1",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.0.2](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v2.0.1...dev-dependencies-types-v2.0.2) (2024-12-11)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([#477](https://github.com/versini-org/dev-dependencies/issues/477)) ([ffd14e9](https://github.com/versini-org/dev-dependencies/commit/ffd14e920bc057e7e2351bac4adc98061d7f6551))
+* bump non-breaking dependencies to latest ([#479](https://github.com/versini-org/dev-dependencies/issues/479)) ([0f8723c](https://github.com/versini-org/dev-dependencies/commit/0f8723ca6665e8d4b110561f58d56d0bf5691664))
+
 ## [2.0.1](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v2.0.0...dev-dependencies-types-v2.0.1) (2024-12-03)
 
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-types",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>dev-dependencies-client: 7.0.1</summary>

## [7.0.1](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v7.0.0...dev-dependencies-client-v7.0.1) (2024-12-11)


### Bug Fixes

* bump non-breaking dependencies to latest ([#477](https://github.com/versini-org/dev-dependencies/issues/477)) ([ffd14e9](https://github.com/versini-org/dev-dependencies/commit/ffd14e920bc057e7e2351bac4adc98061d7f6551))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/dev-dependencies-common bumped to 5.0.1
</details>

<details><summary>dev-dependencies-common: 5.0.1</summary>

## [5.0.1](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v5.0.0...dev-dependencies-common-v5.0.1) (2024-12-11)


### Bug Fixes

* bump non-breaking dependencies to latest ([#477](https://github.com/versini-org/dev-dependencies/issues/477)) ([ffd14e9](https://github.com/versini-org/dev-dependencies/commit/ffd14e920bc057e7e2351bac4adc98061d7f6551))
* bump non-breaking dependencies to latest ([#479](https://github.com/versini-org/dev-dependencies/issues/479)) ([0f8723c](https://github.com/versini-org/dev-dependencies/commit/0f8723ca6665e8d4b110561f58d56d0bf5691664))
</details>

<details><summary>dev-dependencies-server: 6.0.1</summary>

## [6.0.1](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-server-v6.0.0...dev-dependencies-server-v6.0.1) (2024-12-11)


### Bug Fixes

* bump non-breaking dependencies to latest ([#477](https://github.com/versini-org/dev-dependencies/issues/477)) ([ffd14e9](https://github.com/versini-org/dev-dependencies/commit/ffd14e920bc057e7e2351bac4adc98061d7f6551))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/dev-dependencies-common bumped to 5.0.1
</details>

<details><summary>dev-dependencies-types: 2.0.2</summary>

## [2.0.2](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v2.0.1...dev-dependencies-types-v2.0.2) (2024-12-11)


### Bug Fixes

* bump non-breaking dependencies to latest ([#477](https://github.com/versini-org/dev-dependencies/issues/477)) ([ffd14e9](https://github.com/versini-org/dev-dependencies/commit/ffd14e920bc057e7e2351bac4adc98061d7f6551))
* bump non-breaking dependencies to latest ([#479](https://github.com/versini-org/dev-dependencies/issues/479)) ([0f8723c](https://github.com/versini-org/dev-dependencies/commit/0f8723ca6665e8d4b110561f58d56d0bf5691664))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).