### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,6 +2,6 @@
 	"packages/client": "7.0.1",
 	"packages/server": "6.0.1",
 	"packages/common": "5.0.1",
-	"packages/types": "2.0.2",
+	"packages/types": "2.0.3",
 	"packages/eslint": "2.0.0"
 }

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.0.3](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v2.0.2...dev-dependencies-types-v2.0.3) (2024-12-11)
+
+
+### Bug Fixes
+
+* revert to react 18.x types ([#480](https://github.com/versini-org/dev-dependencies/issues/480)) ([273662b](https://github.com/versini-org/dev-dependencies/commit/273662bfff60e6ab8c70dd231bd0803e3a5875ef))
+
 ## [2.0.2](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v2.0.1...dev-dependencies-types-v2.0.2) (2024-12-11)
 
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-types",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>dev-dependencies-types: 2.0.3</summary>

## [2.0.3](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v2.0.2...dev-dependencies-types-v2.0.3) (2024-12-11)


### Bug Fixes

* revert to react 18.x types ([#480](https://github.com/versini-org/dev-dependencies/issues/480)) ([273662b](https://github.com/versini-org/dev-dependencies/commit/273662bfff60e6ab8c70dd231bd0803e3a5875ef))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).