### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,7 @@
 {
-	"packages/client": "7.0.2",
-	"packages/server": "6.0.2",
-	"packages/common": "5.0.1",
-	"packages/types": "3.0.0",
+	"packages/client": "7.0.3",
+	"packages/server": "6.0.3",
+	"packages/common": "5.0.2",
+	"packages/types": "3.0.1",
 	"packages/eslint": "2.0.0"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [7.0.3](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v7.0.2...dev-dependencies-client-v7.0.3) (2024-12-23)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([#485](https://github.com/versini-org/dev-dependencies/issues/485)) ([c0fbf59](https://github.com/versini-org/dev-dependencies/commit/c0fbf5979fd7441bf6fdbe89d98a49eb4237fe76))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/dev-dependencies-common bumped to 5.0.2
+
 ## [7.0.2](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v7.0.1...dev-dependencies-client-v7.0.2) (2024-12-13)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-client",
-	"version": "7.0.2",
+	"version": "7.0.3",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [5.0.2](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v5.0.1...dev-dependencies-common-v5.0.2) (2024-12-23)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([#485](https://github.com/versini-org/dev-dependencies/issues/485)) ([c0fbf59](https://github.com/versini-org/dev-dependencies/commit/c0fbf5979fd7441bf6fdbe89d98a49eb4237fe76))
+
 ## [5.0.1](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v5.0.0...dev-dependencies-common-v5.0.1) (2024-12-11)
 
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-common",
-	"version": "5.0.1",
+	"version": "5.0.2",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [6.0.3](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-server-v6.0.2...dev-dependencies-server-v6.0.3) (2024-12-23)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/dev-dependencies-common bumped to 5.0.2
+
 ## [6.0.2](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-server-v6.0.1...dev-dependencies-server-v6.0.2) (2024-12-13)
 
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-server",
-	"version": "6.0.2",
+	"version": "6.0.3",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.0.1](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v3.0.0...dev-dependencies-types-v3.0.1) (2024-12-23)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([#485](https://github.com/versini-org/dev-dependencies/issues/485)) ([c0fbf59](https://github.com/versini-org/dev-dependencies/commit/c0fbf5979fd7441bf6fdbe89d98a49eb4237fe76))
+
 ## [3.0.0](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v2.0.3...dev-dependencies-types-v3.0.0) (2024-12-13)
 
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-types",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>dev-dependencies-client: 7.0.3</summary>

## [7.0.3](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v7.0.2...dev-dependencies-client-v7.0.3) (2024-12-23)


### Bug Fixes

* bump non-breaking dependencies to latest ([#485](https://github.com/versini-org/dev-dependencies/issues/485)) ([c0fbf59](https://github.com/versini-org/dev-dependencies/commit/c0fbf5979fd7441bf6fdbe89d98a49eb4237fe76))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/dev-dependencies-common bumped to 5.0.2
</details>

<details><summary>dev-dependencies-common: 5.0.2</summary>

## [5.0.2](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v5.0.1...dev-dependencies-common-v5.0.2) (2024-12-23)


### Bug Fixes

* bump non-breaking dependencies to latest ([#485](https://github.com/versini-org/dev-dependencies/issues/485)) ([c0fbf59](https://github.com/versini-org/dev-dependencies/commit/c0fbf5979fd7441bf6fdbe89d98a49eb4237fe76))
</details>

<details><summary>dev-dependencies-server: 6.0.3</summary>

## [6.0.3](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-server-v6.0.2...dev-dependencies-server-v6.0.3) (2024-12-23)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/dev-dependencies-common bumped to 5.0.2
</details>

<details><summary>dev-dependencies-types: 3.0.1</summary>

## [3.0.1](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v3.0.0...dev-dependencies-types-v3.0.1) (2024-12-23)


### Bug Fixes

* bump non-breaking dependencies to latest ([#485](https://github.com/versini-org/dev-dependencies/issues/485)) ([c0fbf59](https://github.com/versini-org/dev-dependencies/commit/c0fbf5979fd7441bf6fdbe89d98a49eb4237fe76))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).