### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,7 @@
 {
-	"packages/client": "7.0.3",
-	"packages/server": "6.0.3",
-	"packages/common": "5.0.2",
-	"packages/types": "3.0.1",
-	"packages/eslint": "2.0.0"
+	"packages/client": "7.0.4",
+	"packages/server": "6.0.4",
+	"packages/common": "5.0.3",
+	"packages/types": "3.0.2",
+	"packages/eslint": "2.0.1"
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [7.0.4](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v7.0.3...dev-dependencies-client-v7.0.4) (2025-01-21)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([#488](https://github.com/versini-org/dev-dependencies/issues/488)) ([213372d](https://github.com/versini-org/dev-dependencies/commit/213372d304a8634a410f88d6b6e3508e7a6b0418))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/dev-dependencies-common bumped to 5.0.3
+
 ## [7.0.3](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v7.0.2...dev-dependencies-client-v7.0.3) (2024-12-23)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-client",
-	"version": "7.0.3",
+	"version": "7.0.4",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [5.0.3](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v5.0.2...dev-dependencies-common-v5.0.3) (2025-01-21)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([#488](https://github.com/versini-org/dev-dependencies/issues/488)) ([213372d](https://github.com/versini-org/dev-dependencies/commit/213372d304a8634a410f88d6b6e3508e7a6b0418))
+
 ## [5.0.2](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v5.0.1...dev-dependencies-common-v5.0.2) (2024-12-23)
 
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-common",
-	"version": "5.0.2",
+	"version": "5.0.3",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/eslint/CHANGELOG.md
+++ b/packages/eslint/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.0.1](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-eslint-v2.0.0...dev-dependencies-eslint-v2.0.1) (2025-01-21)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([#488](https://github.com/versini-org/dev-dependencies/issues/488)) ([213372d](https://github.com/versini-org/dev-dependencies/commit/213372d304a8634a410f88d6b6e3508e7a6b0418))
+
 ## [2.0.0](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-eslint-v1.0.5...dev-dependencies-eslint-v2.0.0) (2024-12-03)
 
 

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-eslint",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [6.0.4](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-server-v6.0.3...dev-dependencies-server-v6.0.4) (2025-01-21)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([#488](https://github.com/versini-org/dev-dependencies/issues/488)) ([213372d](https://github.com/versini-org/dev-dependencies/commit/213372d304a8634a410f88d6b6e3508e7a6b0418))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/dev-dependencies-common bumped to 5.0.3
+
 ## [6.0.3](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-server-v6.0.2...dev-dependencies-server-v6.0.3) (2024-12-23)
 
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-server",
-	"version": "6.0.3",
+	"version": "6.0.4",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.0.2](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v3.0.1...dev-dependencies-types-v3.0.2) (2025-01-21)
+
+
+### Bug Fixes
+
+* bump non-breaking dependencies to latest ([#488](https://github.com/versini-org/dev-dependencies/issues/488)) ([213372d](https://github.com/versini-org/dev-dependencies/commit/213372d304a8634a410f88d6b6e3508e7a6b0418))
+
 ## [3.0.1](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v3.0.0...dev-dependencies-types-v3.0.1) (2024-12-23)
 
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/dev-dependencies-types",
-	"version": "3.0.1",
+	"version": "3.0.2",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>dev-dependencies-client: 7.0.4</summary>

## [7.0.4](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-client-v7.0.3...dev-dependencies-client-v7.0.4) (2025-01-21)


### Bug Fixes

* bump non-breaking dependencies to latest ([#488](https://github.com/versini-org/dev-dependencies/issues/488)) ([213372d](https://github.com/versini-org/dev-dependencies/commit/213372d304a8634a410f88d6b6e3508e7a6b0418))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/dev-dependencies-common bumped to 5.0.3
</details>

<details><summary>dev-dependencies-common: 5.0.3</summary>

## [5.0.3](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v5.0.2...dev-dependencies-common-v5.0.3) (2025-01-21)


### Bug Fixes

* bump non-breaking dependencies to latest ([#488](https://github.com/versini-org/dev-dependencies/issues/488)) ([213372d](https://github.com/versini-org/dev-dependencies/commit/213372d304a8634a410f88d6b6e3508e7a6b0418))
</details>

<details><summary>dev-dependencies-eslint: 2.0.1</summary>

## [2.0.1](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-eslint-v2.0.0...dev-dependencies-eslint-v2.0.1) (2025-01-21)


### Bug Fixes

* bump non-breaking dependencies to latest ([#488](https://github.com/versini-org/dev-dependencies/issues/488)) ([213372d](https://github.com/versini-org/dev-dependencies/commit/213372d304a8634a410f88d6b6e3508e7a6b0418))
</details>

<details><summary>dev-dependencies-server: 6.0.4</summary>

## [6.0.4](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-server-v6.0.3...dev-dependencies-server-v6.0.4) (2025-01-21)


### Bug Fixes

* bump non-breaking dependencies to latest ([#488](https://github.com/versini-org/dev-dependencies/issues/488)) ([213372d](https://github.com/versini-org/dev-dependencies/commit/213372d304a8634a410f88d6b6e3508e7a6b0418))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/dev-dependencies-common bumped to 5.0.3
</details>

<details><summary>dev-dependencies-types: 3.0.2</summary>

## [3.0.2](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-types-v3.0.1...dev-dependencies-types-v3.0.2) (2025-01-21)


### Bug Fixes

* bump non-breaking dependencies to latest ([#488](https://github.com/versini-org/dev-dependencies/issues/488)) ([213372d](https://github.com/versini-org/dev-dependencies/commit/213372d304a8634a410f88d6b6e3508e7a6b0418))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).